### PR TITLE
Add snippet scheduling, S3 storage and UI tweaks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
             <artifactId>sqs</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
             <version>3.5.3</version>

--- a/src/main/java/com/libraries/saas/config/S3Config.java
+++ b/src/main/java/com/libraries/saas/config/S3Config.java
@@ -1,0 +1,28 @@
+package com.libraries.saas.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.region.static}")
+    private String region;
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+}

--- a/src/main/java/com/libraries/saas/config/SchedulerConfig.java
+++ b/src/main/java/com/libraries/saas/config/SchedulerConfig.java
@@ -1,0 +1,17 @@
+package com.libraries.saas.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.TaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/com/libraries/saas/controller/IndexController.java
+++ b/src/main/java/com/libraries/saas/controller/IndexController.java
@@ -23,4 +23,10 @@ public class IndexController {
 
         return "index";
     }
+
+    @GetMapping("/snippets")
+    public String snippets(HttpSession session) {
+        if (session.getAttribute("token") == null) return "redirect:/login";
+        return "snippets";
+    }
 }

--- a/src/main/java/com/libraries/saas/controller/SnippetController.java
+++ b/src/main/java/com/libraries/saas/controller/SnippetController.java
@@ -1,0 +1,50 @@
+package com.libraries.saas.controller;
+
+import com.libraries.saas.dto.Snippet;
+import com.libraries.saas.services.SnippetService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/snippets")
+public class SnippetController {
+    private final SnippetService snippetService;
+
+    public SnippetController(SnippetService snippetService) {
+        this.snippetService = snippetService;
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<Void> save(@RequestParam("token") String token,
+                                     @RequestBody Snippet snippet) {
+        try {
+            snippetService.saveSnippet(token, snippet);
+            return ResponseEntity.ok().build();
+        } catch (IOException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Snippet>> list(@RequestParam("token") String token) {
+        try {
+            return ResponseEntity.ok(snippetService.listSnippets(token));
+        } catch (IOException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PostMapping("/run")
+    public ResponseEntity<Void> run(@RequestParam("token") String token,
+                                    @RequestParam("name") String name) {
+        try {
+            snippetService.runSnippet(token, name);
+            return ResponseEntity.ok().build();
+        } catch (IOException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+}

--- a/src/main/java/com/libraries/saas/dto/Snippet.java
+++ b/src/main/java/com/libraries/saas/dto/Snippet.java
@@ -1,0 +1,31 @@
+package com.libraries.saas.dto;
+
+import java.util.List;
+
+public class Snippet {
+    private String name;
+    private String code;
+    private List<String> dependencies;
+    private String cron; // cron expression
+
+    public Snippet() {}
+
+    public Snippet(String name, String code, List<String> dependencies, String cron) {
+        this.name = name;
+        this.code = code;
+        this.dependencies = dependencies;
+        this.cron = cron;
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+
+    public List<String> getDependencies() { return dependencies; }
+    public void setDependencies(List<String> dependencies) { this.dependencies = dependencies; }
+
+    public String getCron() { return cron; }
+    public void setCron(String cron) { this.cron = cron; }
+}

--- a/src/main/java/com/libraries/saas/services/SnippetService.java
+++ b/src/main/java/com/libraries/saas/services/SnippetService.java
@@ -1,0 +1,93 @@
+package com.libraries.saas.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.libraries.auth.dto.UserInfoDto;
+import com.libraries.auth.repository.UserRepository;
+import com.libraries.saas.dto.CodeRequest;
+import com.libraries.saas.dto.Snippet;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+
+@Service
+public class SnippetService {
+    private final S3Client s3;
+    private final String bucket;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final JobService jobService;
+    private final UserRepository userRepository;
+    private final TaskScheduler scheduler;
+    private final List<ScheduledFuture<?>> tasks = new ArrayList<>();
+
+    public SnippetService(S3Client s3,
+                          @Value("${app.s3.bucket-name}") String bucket,
+                          JobService jobService,
+                          UserRepository userRepository,
+                          TaskScheduler scheduler) {
+        this.s3 = s3;
+        this.bucket = bucket;
+        this.jobService = jobService;
+        this.userRepository = userRepository;
+        this.scheduler = scheduler;
+    }
+
+    public void saveSnippet(String token, Snippet snippet) throws IOException {
+        UserInfoDto info = userRepository.getUserInfo(token);
+        if (info == null) throw new IllegalArgumentException("Invalid token");
+        String key = info.id() + "/snippets/" + snippet.getName() + ".json";
+        byte[] data = mapper.writeValueAsBytes(snippet);
+        s3.putObject(PutObjectRequest.builder().bucket(bucket).key(key).build(),
+                new ByteArrayInputStream(data), data.length);
+        if (snippet.getCron() != null && !snippet.getCron().isBlank()) {
+            scheduleSnippet(snippet, token);
+        }
+    }
+
+    public List<Snippet> listSnippets(String token) throws IOException {
+        UserInfoDto info = userRepository.getUserInfo(token);
+        if (info == null) throw new IllegalArgumentException("Invalid token");
+        String prefix = info.id() + "/snippets/";
+        var req = ListObjectsV2Request.builder().bucket(bucket).prefix(prefix).build();
+        var res = s3.listObjectsV2(req);
+        List<Snippet> snippets = new ArrayList<>();
+        for (var obj : res.contents()) {
+            var get = GetObjectRequest.builder().bucket(bucket).key(obj.key()).build();
+            var bytes = s3.getObjectAsBytes(get).asByteArray();
+            snippets.add(mapper.readValue(bytes, Snippet.class));
+        }
+        return snippets;
+    }
+
+    public void runSnippet(String token, String name) throws IOException {
+        UserInfoDto info = userRepository.getUserInfo(token);
+        if (info == null) throw new IllegalArgumentException("Invalid token");
+        String key = info.id() + "/snippets/" + name + ".json";
+        var get = GetObjectRequest.builder().bucket(bucket).key(key).build();
+        var bytes = s3.getObjectAsBytes(get).asByteArray();
+        Snippet snippet = mapper.readValue(bytes, Snippet.class);
+        jobService.submitJob(new CodeRequest(snippet.getCode(), snippet.getDependencies()));
+    }
+
+    private void scheduleSnippet(Snippet snippet, String token) {
+        Runnable task = () -> {
+            try {
+                jobService.submitJob(new CodeRequest(snippet.getCode(), snippet.getDependencies()));
+            } catch (Exception ignored) {}
+        };
+        CronTrigger trigger = new CronTrigger(snippet.getCron());
+        ScheduledFuture<?> future = scheduler.schedule(task, trigger);
+        tasks.add(future);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,4 @@ sentry.traces-sample-rate=1.0
 sentry.spring-web.enabled=true
 sentry.servlet-tracing-enabled=true
 spring.main.allow-bean-definition-overriding=true
+app.s3.bucket-name=saas-eduard

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -10,7 +10,6 @@
 
     <style>
         #editor{height:300px;width:100%;border:1px solid #d1d5db;border-radius:.375rem}
-        #output-overlay.hidden{display:none}
     </style>
 
     <!-- Chart.js & Monaco -->
@@ -29,6 +28,7 @@
         <h1 class="text-2xl font-bold mb-8">My Dashboard</h1>
         <nav class="flex-1 space-y-4 text-sm">
             <a href="#overview"  class="block py-2 px-4 rounded hover:bg-gray-100 transition">Overview</a>
+            <a th:href="@{/snippets}"  class="block py-2 px-4 rounded hover:bg-gray-100 transition">Snippets</a>
             <a href="#settings"  class="block py-2 px-4 rounded hover:bg-gray-100 transition">Settings</a>
         </nav>
         <a th:href="@{/logout}" class="mt-auto block py-2 px-4 rounded text-red-600 hover:bg-red-50 text-center transition">Logout</a>
@@ -120,15 +120,9 @@
 
             </section>
 
-            <!-- Fullscreen output overlay -->
-            <div id="output-overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center z-50">
-                <div class="bg-white rounded-lg shadow-lg w-11/12 h-5/6 relative flex flex-col">
-                    <button id="close-output" type="button" class="absolute top-2 right-2 text-gray-600 hover:text-black">&times;</button>
-                    <pre id="fullscreen-output" class="flex-1 overflow-auto p-4 text-sm bg-gray-50"></pre>
-                    <div class="p-2 border-t flex justify-end">
-                        <button id="cancel-job" type="button" class="bg-red-600 text-white px-3 py-1 rounded hover:bg-red-700">Stop</button>
-                    </div>
-                </div>
+            <!-- Cancel button -->
+            <div class="mt-2">
+                <button id="cancel-job" type="button" class="bg-red-600 text-white px-3 py-1 rounded hover:bg-red-700">Stop</button>
             </div>
 
             <!-- Monaco -->
@@ -152,12 +146,8 @@
                     const statusText = document.getElementById('status-text');
                     const statusIndicator = document.getElementById('status-indicator');
                     const output = document.getElementById('code-output');
-                    const overlay = document.getElementById('output-overlay');
-                    const fullscreenOut = document.getElementById('fullscreen-output');
                     const cancelBtn = document.getElementById('cancel-job');
-                    const closeBtn = document.getElementById('close-output');
                     let currentJob = null;
-                    closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));
 
                     /* Thymeleaf inlines the real token; empty string is the fallback when not logged in */
                     const token  = /*[[${session.token}]]*/ '';
@@ -207,10 +197,6 @@
 
                             setStatus(`Status: ${json.status}`, colorMap[json.status] || 'gray-400');
                             output.innerHTML = json.output || '';
-                            if (!overlay.classList.contains('hidden')) {
-                                fullscreenOut.innerHTML = json.output || '';
-                                fullscreenOut.scrollTop = fullscreenOut.scrollHeight;
-                            }
                             output.scrollTop = output.scrollHeight;
 
                             if (json.status === 'job_pending' || json.status === 'running') {
@@ -234,8 +220,6 @@
                         setRunning(true);
                         setStatus('Submitting…', 'blue-500');
                         output.innerHTML = '';
-                        fullscreenOut.innerHTML = '';
-                        overlay.classList.remove('hidden');
                         cancelBtn.disabled = true;
 
                         const pomText = document.getElementById('pom-editor').value;
@@ -266,7 +250,6 @@
                                 cancelBtn.disabled = true;
                                 await fetch(`/code-execution/cancel?token=${encodeURIComponent(token)}&id=${currentJob}`, {method: 'POST'});
                                 setStatus('Cancelled', 'red-500');
-                                overlay.classList.add('hidden');
                                 setRunning(false);
                             };
                             poll(json.jobId);

--- a/src/main/resources/templates/snippets.html
+++ b/src/main/resources/templates/snippets.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Snippets</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-6 space-y-4">
+<h2 class="text-xl font-semibold">Saved Snippets</h2>
+<div id="snippets-list" class="space-y-2"></div>
+
+<h3 class="text-lg font-medium mt-4">New Snippet</h3>
+<div class="space-y-2">
+    <input id="snip-name" type="text" placeholder="Name" class="border p-2 rounded w-full"/>
+    <textarea id="snip-code" class="border p-2 rounded w-full h-40" placeholder="public class Job {}"></textarea>
+    <textarea id="snip-deps" class="border p-2 rounded w-full h-20" placeholder="&lt;dependencies&gt;...&lt;/dependencies&gt;"></textarea>
+    <input id="snip-cron" type="text" placeholder="Cron expression" class="border p-2 rounded w-full"/>
+    <button id="save-snip" class="bg-indigo-600 text-white px-4 py-2 rounded">Save</button>
+</div>
+
+<script th:inline="javascript">
+/*<![CDATA[*/
+(function(){
+    const token = /*[[${session.token}]]*/ '';
+    const list  = document.getElementById('snippets-list');
+
+    function parsePomDependencies(xml){
+        const deps=[];
+        const rx=/<dependency>[\s\S]*?<groupId>(.*?)<\/groupId>[\s\S]*?<artifactId>(.*?)<\/artifactId>(?:[\s\S]*?<version>(.*?)<\/version>)?[\s\S]*?<\/dependency>/gi;
+        let m;while((m=rx.exec(xml))!==null){
+            const coord=m[3]&&m[3].trim()?`${m[1]}:${m[2]}:${m[3]}`:`${m[1]}:${m[2]}`;
+            deps.push(coord);
+        }
+        return deps;
+    }
+
+    async function load(){
+        const res = await fetch(`/snippets?token=${encodeURIComponent(token)}`);
+        if(!res.ok) return;
+        const data = await res.json();
+        list.innerHTML = data.map(s=>`<div class='border p-2 rounded'>${s.name} <button data-n='${s.name}' class='run bg-green-600 text-white px-2 py-1 rounded ml-2'>Run</button></div>`).join('');
+        document.querySelectorAll('button.run').forEach(b=>{
+            b.onclick=async()=>{
+                await fetch(`/snippets/run?token=${encodeURIComponent(token)}&name=${b.dataset.n}`,{method:'POST'});
+            };
+        });
+    }
+    load();
+
+    document.getElementById('save-snip').onclick = async () => {
+        const body = {
+            name: document.getElementById('snip-name').value,
+            code: document.getElementById('snip-code').value,
+            dependencies: parsePomDependencies(document.getElementById('snip-deps').value),
+            cron: document.getElementById('snip-cron').value
+        };
+        await fetch(`/snippets/save?token=${encodeURIComponent(token)}`,{
+            method:'POST',headers:{'Content-Type':'application/json'},
+            body:JSON.stringify(body)
+        });
+        load();
+    };
+})();
+/*]]>*/
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- store user snippets in S3 and allow scheduling via cron
- expose SnippetController API
- provide scheduler and S3 configuration
- add new Snippets page and navigation link
- remove fullscreen overlay from code execution UI
- configure bucket in application properties

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch)*
- `./mvnw test` *(fails: Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_686195e468bc8324bdb11491d7223c7e