### PR TITLE
Add snippet scheduling fixes and run history

### DIFF
--- a/src/main/java/com/libraries/saas/controller/HistoryController.java
+++ b/src/main/java/com/libraries/saas/controller/HistoryController.java
@@ -1,0 +1,37 @@
+package com.libraries.saas.controller;
+
+import com.libraries.auth.dto.UserInfoDto;
+import com.libraries.auth.repository.UserRepository;
+import com.libraries.saas.dto.RunRecord;
+import com.libraries.saas.services.RunHistoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/history")
+public class HistoryController {
+    private final RunHistoryService historyService;
+    private final UserRepository userRepository;
+
+    public HistoryController(RunHistoryService historyService, UserRepository userRepository) {
+        this.historyService = historyService;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<RunRecord>> history(@RequestParam("token") String token) {
+        try {
+            UserInfoDto info = userRepository.getUserInfo(token);
+            if (info == null) return ResponseEntity.badRequest().build();
+            return ResponseEntity.ok(historyService.list(info.id()));
+        } catch (IOException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+}

--- a/src/main/java/com/libraries/saas/controller/JobController.java
+++ b/src/main/java/com/libraries/saas/controller/JobController.java
@@ -41,7 +41,7 @@ public class JobController {
             if  (userInfo == null || !userInfo.roles().map(list -> list.contains("code-execution")).orElse(false)) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
             }
-            String jobId = jobService.submitJob(new CodeRequest(request.getCode(), request.getDependencies()));
+            String jobId = jobService.submitJob(new CodeRequest(request.getCode(), request.getDependencies()), userInfo.id(), null);
             return ResponseEntity.ok(Collections.singletonMap("jobId", jobId));
         } catch (Exception e) {
             return ResponseEntity.badRequest().build();

--- a/src/main/java/com/libraries/saas/dto/RunRecord.java
+++ b/src/main/java/com/libraries/saas/dto/RunRecord.java
@@ -1,0 +1,41 @@
+package com.libraries.saas.dto;
+
+import java.time.Instant;
+
+public class RunRecord {
+    private String jobId;
+    private String snippetName;
+    private Instant timestamp;
+    private String status;
+    private String output;
+    private String error;
+
+    public RunRecord() {}
+
+    public RunRecord(String jobId, String snippetName, Instant timestamp, String status, String output, String error) {
+        this.jobId = jobId;
+        this.snippetName = snippetName;
+        this.timestamp = timestamp;
+        this.status = status;
+        this.output = output;
+        this.error = error;
+    }
+
+    public String getJobId() { return jobId; }
+    public void setJobId(String jobId) { this.jobId = jobId; }
+
+    public String getSnippetName() { return snippetName; }
+    public void setSnippetName(String snippetName) { this.snippetName = snippetName; }
+
+    public Instant getTimestamp() { return timestamp; }
+    public void setTimestamp(Instant timestamp) { this.timestamp = timestamp; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getOutput() { return output; }
+    public void setOutput(String output) { this.output = output; }
+
+    public String getError() { return error; }
+    public void setError(String error) { this.error = error; }
+}

--- a/src/main/java/com/libraries/saas/services/RunHistoryService.java
+++ b/src/main/java/com/libraries/saas/services/RunHistoryService.java
@@ -1,0 +1,55 @@
+package com.libraries.saas.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.libraries.saas.dto.RunRecord;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class RunHistoryService {
+    private final S3Client s3;
+    private final String bucket;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public RunHistoryService(S3Client s3, @Value("${app.s3.bucket-name}") String bucket) {
+        this.s3 = s3;
+        this.bucket = bucket;
+    }
+
+    public void record(String userId, RunRecord record) {
+        try {
+            byte[] data = mapper.writeValueAsBytes(record);
+            String key = userId + "/history/" + record.getJobId() + ".json";
+            s3.putObject(PutObjectRequest.builder().bucket(bucket).key(key).build(),
+                    new ByteArrayInputStream(data), data.length);
+        } catch (Exception ignored) {
+        }
+    }
+
+    public List<RunRecord> list(String userId) throws IOException {
+        List<RunRecord> list = new ArrayList<>();
+        String prefix = userId + "/history/";
+        var res = s3.listObjectsV2(ListObjectsV2Request.builder().bucket(bucket).prefix(prefix).build());
+        for (var obj : res.contents()) {
+            var get = GetObjectRequest.builder().bucket(bucket).key(obj.key()).build();
+            var bytes = s3.getObjectAsBytes(get).asByteArray();
+            list.add(mapper.readValue(bytes, RunRecord.class));
+        }
+        list.sort((a, b) -> b.getTimestamp().compareTo(a.getTimestamp()));
+        return list;
+    }
+
+    public RunRecord newRecord(String jobId, String snippetName, String status, String output, String error) {
+        return new RunRecord(jobId, snippetName, Instant.now(), status, output, error);
+    }
+}

--- a/src/main/resources/templates/snippets.html
+++ b/src/main/resources/templates/snippets.html
@@ -5,17 +5,31 @@
     <title>Snippets</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="p-6 space-y-4">
-<h2 class="text-xl font-semibold">Saved Snippets</h2>
-<div id="snippets-list" class="space-y-2"></div>
+<body class="p-6 space-y-8 bg-gray-50 min-h-screen">
+<h2 class="text-2xl font-semibold">Saved Snippets</h2>
+<div id="snippets-list" class="grid gap-4 md:grid-cols-2"></div>
 
-<h3 class="text-lg font-medium mt-4">New Snippet</h3>
-<div class="space-y-2">
+<h3 class="text-xl font-medium mt-6">New Snippet</h3>
+<div class="space-y-2 bg-white p-4 rounded shadow">
     <input id="snip-name" type="text" placeholder="Name" class="border p-2 rounded w-full"/>
     <textarea id="snip-code" class="border p-2 rounded w-full h-40" placeholder="public class Job {}"></textarea>
     <textarea id="snip-deps" class="border p-2 rounded w-full h-20" placeholder="&lt;dependencies&gt;...&lt;/dependencies&gt;"></textarea>
     <input id="snip-cron" type="text" placeholder="Cron expression" class="border p-2 rounded w-full"/>
     <button id="save-snip" class="bg-indigo-600 text-white px-4 py-2 rounded">Save</button>
+</div>
+
+<h3 class="text-xl font-medium mt-8">Run History</h3>
+<div class="overflow-x-auto bg-white rounded shadow">
+    <table class="min-w-full text-sm" id="history-table">
+        <thead class="bg-gray-100">
+        <tr>
+            <th class="px-4 py-2 text-left">Time</th>
+            <th class="px-4 py-2 text-left">Snippet</th>
+            <th class="px-4 py-2 text-left">Status</th>
+        </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
 </div>
 
 <script th:inline="javascript">
@@ -38,14 +52,30 @@
         const res = await fetch(`/api/snippets?token=${encodeURIComponent(token)}`);
         if(!res.ok) return;
         const data = await res.json();
-        list.innerHTML = data.map(s=>`<div class='border p-2 rounded'>${s.name} <button data-n='${s.name}' class='run bg-green-600 text-white px-2 py-1 rounded ml-2'>Run</button></div>`).join('');
+        list.innerHTML = data.map(s=>`<div class='border p-4 rounded bg-white shadow flex justify-between items-center'>`+
+            `<span>${s.name}</span>`+
+            `<button data-n='${s.name}' class='run bg-green-600 text-white px-2 py-1 rounded'>Run</button>`+
+            `</div>`).join('');
         document.querySelectorAll('button.run').forEach(b=>{
             b.onclick=async()=>{
                 await fetch(`/api/snippets/run?token=${encodeURIComponent(token)}&name=${b.dataset.n}`,{method:'POST'});
+                loadHistory();
             };
         });
     }
     load();
+
+    async function loadHistory(){
+        const res = await fetch(`/api/history?token=${encodeURIComponent(token)}`);
+        if(!res.ok) return;
+        const data = await res.json();
+        const tbody = document.querySelector('#history-table tbody');
+        tbody.innerHTML = data.map(r=>{
+            const ts = new Date(r.timestamp).toLocaleString();
+            return `<tr><td class='px-4 py-1 border-b'>${ts}</td><td class='px-4 py-1 border-b'>${r.snippetName||'-'}</td><td class='px-4 py-1 border-b'>${r.status}</td></tr>`;
+        }).join('');
+    }
+    loadHistory();
 
     document.getElementById('save-snip').onclick = async () => {
         const body = {


### PR DESCRIPTION
## Summary
- allow 5-field cron expressions when scheduling snippets
- store run history in S3 and expose via REST
- record job executions per user
- improve snippets page with history table

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861997ea26c832481b12512f6807d9c