### PR TITLE
Add scheduled job persistence and UI updates

### DIFF
--- a/src/main/java/com/libraries/saas/controller/SnippetController.java
+++ b/src/main/java/com/libraries/saas/controller/SnippetController.java
@@ -1,6 +1,7 @@
 package com.libraries.saas.controller;
 
 import com.libraries.saas.dto.Snippet;
+import com.libraries.saas.dto.ScheduledSnippet;
 import com.libraries.saas.services.SnippetService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -43,6 +44,15 @@ public class SnippetController {
         try {
             snippetService.runSnippet(token, name);
             return ResponseEntity.ok().build();
+        } catch (IOException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @GetMapping("/scheduled")
+    public ResponseEntity<List<ScheduledSnippet>> scheduled(@RequestParam("token") String token) {
+        try {
+            return ResponseEntity.ok(snippetService.scheduledWithHistory(token));
         } catch (IOException e) {
             return ResponseEntity.badRequest().build();
         }

--- a/src/main/java/com/libraries/saas/dto/ScheduledSnippet.java
+++ b/src/main/java/com/libraries/saas/dto/ScheduledSnippet.java
@@ -1,0 +1,22 @@
+package com.libraries.saas.dto;
+
+import java.util.List;
+
+public class ScheduledSnippet {
+    private Snippet snippet;
+    private List<RunRecord> history;
+
+    public ScheduledSnippet() {}
+
+    public ScheduledSnippet(Snippet snippet, List<RunRecord> history) {
+        this.snippet = snippet;
+        this.history = history;
+    }
+
+    public Snippet getSnippet() { return snippet; }
+    public void setSnippet(Snippet snippet) { this.snippet = snippet; }
+
+    public List<RunRecord> getHistory() { return history; }
+    public void setHistory(List<RunRecord> history) { this.history = history; }
+}
+

--- a/src/main/java/com/libraries/saas/services/RunHistoryService.java
+++ b/src/main/java/com/libraries/saas/services/RunHistoryService.java
@@ -9,7 +9,6 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -31,7 +30,7 @@ public class RunHistoryService {
             byte[] data = mapper.writeValueAsBytes(record);
             String key = userId + "/history/" + record.getJobId() + ".json";
             s3.putObject(PutObjectRequest.builder().bucket(bucket).key(key).build(),
-                    new ByteArrayInputStream(data), data.length);
+                    software.amazon.awssdk.core.sync.RequestBody.fromBytes(data));
         } catch (Exception ignored) {
         }
     }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org" class="h-full bg-gray-50">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" class="h-full" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">
     <title>Dashboard</title>
     <meta th:if="${session.token == null}" http-equiv="refresh" content="0;url=/login"/>
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/darkly/bootstrap.min.css">
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
 

--- a/src/main/resources/templates/snippets.html
+++ b/src/main/resources/templates/snippets.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org" class="h-full bg-gray-50">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" class="h-full" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">
     <title>Snippets</title>
     <meta th:if="${session.token == null}" http-equiv="refresh" content="0;url=/login"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/darkly/bootstrap.min.css">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config={theme:{extend:{keyframes:{fadeIn:{'0%':{opacity:0},'100%':{opacity:1}}},animation:{'fade-in':'fadeIn 0.4s ease-out forwards'}}}};
@@ -14,8 +15,9 @@
     <aside class="hidden lg:flex lg:flex-col lg:w-1/5 bg-white border-r text-gray-700 p-6">
         <h1 class="text-2xl font-bold mb-8">My Dashboard</h1>
         <nav class="flex-1 space-y-4 text-sm">
-            <a th:href="@{/}" class="block py-2 px-4 rounded hover:bg-gray-100 transition">Main Board</a>
-            <a th:href="@{/snippets}" class="block py-2 px-4 rounded bg-gray-100">Snippets</a>
+            <a href="#overview"  class="block py-2 px-4 rounded hover:bg-gray-100 transition">Overview</a>
+            <a th:href="@{/snippets}"  class="block py-2 px-4 rounded hover:bg-gray-100 transition">Snippets</a>
+            <a href="#settings"  class="block py-2 px-4 rounded hover:bg-gray-100 transition">Settings</a>
         </nav>
         <a th:href="@{/logout}" class="mt-auto block py-2 px-4 rounded text-red-600 hover:bg-red-50 text-center transition">Logout</a>
     </aside>
@@ -41,18 +43,7 @@
             </section>
             <section>
                 <h3 class="text-xl font-medium mb-2">Run History</h3>
-                <div class="overflow-x-auto bg-white rounded shadow">
-                    <table class="min-w-full text-sm" id="history-table">
-                        <thead class="bg-gray-100">
-                        <tr>
-                            <th class="px-4 py-2 text-left">Time</th>
-                            <th class="px-4 py-2 text-left">Snippet</th>
-                            <th class="px-4 py-2 text-left">Status</th>
-                        </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </div>
+                <div id="history-list" class="space-y-2"></div>
             </section>
         </main>
     </div>
@@ -96,13 +87,18 @@
     load();
 
     async function loadHistory(){
-        const res = await fetch(`/api/history?token=${encodeURIComponent(token)}`);
+        const res = await fetch(`/api/snippets/scheduled?token=${encodeURIComponent(token)}`);
         if(!res.ok) return;
         const data = await res.json();
-        const tbody = document.querySelector('#history-table tbody');
-        tbody.innerHTML = data.map(r=>{
-            const ts = new Date(r.timestamp).toLocaleString();
-            return `<tr><td class='px-4 py-1 border-b'>${ts}</td><td class='px-4 py-1 border-b'>${r.snippetName||'-'}</td><td class='px-4 py-1 border-b'>${r.status}</td></tr>`;
+        const container = document.getElementById('history-list');
+        container.innerHTML = data.map(s=>{
+            const runs = s.history.map(r=>{
+                const ts = new Date(r.timestamp).toLocaleString();
+                const out = r.output?`<pre class='bg-dark text-light p-2 rounded'>${r.output}</pre>`:'';
+                const err = r.error?`<pre class='bg-danger text-light p-2 rounded'>${r.error}</pre>`:'';
+                return `<div class='mb-2'>${ts} - ${r.status}${out}${err}</div>`;
+            }).join('');
+            return `<details><summary>${s.snippet.name} (${s.snippet.cron})</summary>${runs}</details>`;
         }).join('');
     }
     loadHistory();


### PR DESCRIPTION
## Summary
- load scheduled snippets from S3 on startup and allow listing with history
- return scheduled snippets via new `/api/snippets/scheduled` API
- store run history using `RequestBody.fromBytes`
- add `ScheduledSnippet` DTO
- update snippets page sidebar and dark bootstrap theme
- enhance snippets page to show run history as expandables
- apply dark bootstrap theme to index page

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861a08d3fa88324931847237b1872eb